### PR TITLE
Remove log noise

### DIFF
--- a/responders.go
+++ b/responders.go
@@ -21,17 +21,6 @@ func (rs *PublishResponder) Respond(response *Request) error {
 	destinationRoute := response.Routing.RouteTo[destinationRouteIndex]
 	response.Routing.RouteTo = response.Routing.RouteTo[:destinationRouteIndex]
 
-	routeTo := ""
-	if len(response.GetRouting().GetRouteTo()) > 0 {
-		routeTo = response.GetRouting().GetRouteTo()[0].GetUri()
-	}
-
-	logger.WithFields(logrus.Fields{
-		"request_uuid": response.GetUuid(),
-		"trace_uuid":   response.GetTrace().GetUuid(),
-		"route_to":     routeTo,
-	}).Debug("publishing response")
-
 	responseBytes, err := Marshal(response)
 	if err != nil {
 		return errors.Wrap(err, "publish responder failed to marshal response")


### PR DESCRIPTION
So we can look at the logs. Currently, this one message is a huge percentage of the output.